### PR TITLE
Pubstack Adapter: resolve placement telemetry DOM id

### DIFF
--- a/modules/pubstackBidAdapter.ts
+++ b/modules/pubstackBidAdapter.ts
@@ -54,16 +54,18 @@ const getElementForAdUnitCode = (adUnitCode: string): HTMLElement | undefined =>
 
 const converter = ortbConverter({
   imp(buildImp, bidRequest: BidRequest<typeof BIDDER_CODE>, context) {
-    const element = getElementForAdUnitCode(bidRequest.adUnitCode);
-    const placementInfo = getPlacementInfo(bidRequest);
     const imp = buildImp(bidRequest, context);
-    deepSetValue(imp, `ext.prebid.bidder.${BIDDER_CODE}.adUnitName`, bidRequest.params.adUnitName);
-    deepSetValue(imp, `ext.prebid.placement.code`, bidRequest.adUnitCode);
+    const element = getElementForAdUnitCode(bidRequest.adUnitCode);
+    const placementDomId = element?.id ?? bidRequest.adUnitCode;
+    const placementInfo = getPlacementInfo({...bidRequest, adUnitCode: placementDomId});
     deepSetValue(imp, `ext.prebid.placement.domId`, element?.id);
     deepSetValue(imp, `ext.prebid.placement.viewability`, placementInfo.PlacementPercentView);
     deepSetValue(imp, `ext.prebid.placement.viewportDistance`, placementInfo.DistanceToView);
     deepSetValue(imp, `ext.prebid.placement.height`, placementInfo.ElementHeight);
     deepSetValue(imp, `ext.prebid.placement.auctionsCount`, placementInfo.AuctionsCount);
+    deepSetValue(imp, `ext.prebid.bidder.${BIDDER_CODE}.adUnitName`, bidRequest.params.adUnitName);
+    deepSetValue(imp, `ext.prebid.placement.adUnitCode`, bidRequest.adUnitCode);
+
     return imp;
   },
   request(buildRequest, imps, bidderRequest, context) {

--- a/test/spec/modules/pubstackBidAdapter_spec.js
+++ b/test/spec/modules/pubstackBidAdapter_spec.js
@@ -114,7 +114,7 @@ describe('pubstackBidAdapter', function () {
       expect(request.data.imp).to.have.lengthOf(1);
       expect(utils.deepAccess(request, 'data.imp.0.id')).to.equal('bid-1');
       expect(utils.deepAccess(request, 'data.imp.0.ext.prebid.bidder.pubstack.adUnitName')).to.equal('adunit-1');
-      expect(utils.deepAccess(request, 'data.imp.0.ext.prebid.placement.code')).to.equal('adunit-code');
+      expect(utils.deepAccess(request, 'data.imp.0.ext.prebid.placement.adUnitCode')).to.equal('adunit-code');
       expect(utils.deepAccess(request, 'data.imp.0.ext.prebid.placement.viewability')).to.be.a('number');
       expect(utils.deepAccess(request, 'data.imp.0.ext.prebid.placement.viewportDistance')).to.be.a('number');
       expect(utils.deepAccess(request, 'data.imp.0.ext.prebid.placement.height')).to.be.a('number');


### PR DESCRIPTION
## Type of issue
- [x] fix

## Description
Use the resolved slot element id when Pubstack computes placement telemetry, while still sending the original ad unit code separately in `ext.prebid.placement.adUnitCode`. This keeps placement metrics populated while making GPT-backed slots resolve against the actual DOM node. See `modules/pubstackBidAdapter.ts#L56-L67` and `test/spec/modules/pubstackBidAdapter_spec.js#L105-L127`.
