### PR TITLE
fix: add default value for tll & netRevenue

### DIFF
--- a/modules/pubstackBidAdapter.ts
+++ b/modules/pubstackBidAdapter.ts
@@ -28,6 +28,14 @@ declare module '../src/adUnits' {
   }
 }
 
+type OpenRtbBid = {
+  impid?: string;
+  ttl?: number;
+  exp?: number;
+  netRevenue?: boolean;
+  netrevenue?: boolean;
+};
+
 type GetUserSyncFn = (
   syncOptions: {
     iframeEnabled: boolean;
@@ -112,7 +120,7 @@ const buildRequests = (
   };
 };
 
-const mapResponseBidsByImpId = (responseBody) => new Map(
+const mapResponseBidsByImpId = (responseBody) => new Map<string, OpenRtbBid>(
   (responseBody?.seatbid ?? [])
     .flatMap(seatBid => seatBid?.bid ?? [])
     .filter(bid => bid?.impid)

--- a/modules/pubstackBidAdapter.ts
+++ b/modules/pubstackBidAdapter.ts
@@ -33,7 +33,6 @@ type OpenRtbBid = {
   ttl?: number;
   exp?: number;
   netRevenue?: boolean;
-  netrevenue?: boolean;
 };
 
 type GetUserSyncFn = (

--- a/modules/pubstackBidAdapter.ts
+++ b/modules/pubstackBidAdapter.ts
@@ -16,6 +16,8 @@ const GVLID = 1408;
 const REQUEST_URL = 'https://node.pbstck.com/openrtb2/auction';
 const COOKIESYNC_IFRAME_URL = 'https://cdn.pbstck.com/async_usersync.html';
 const COOKIESYNC_PIXEL_URL = 'https://cdn.pbstck.com/async_usersync.png';
+const DEFAULT_TTL = 300;
+const DEFAULT_NET_REVENUE = true;
 
 declare module '../src/adUnits' {
   interface BidderParams {
@@ -110,11 +112,37 @@ const buildRequests = (
   };
 };
 
+const mapResponseBidsByImpId = (responseBody) => new Map(
+  (responseBody?.seatbid ?? [])
+    .flatMap(seatBid => seatBid?.bid ?? [])
+    .filter(bid => bid?.impid)
+    .map(bid => [bid.impid, bid]),
+);
+
+const enrichBidResponse = (adapterResponse, responseBody) => {
+  const rawBidsByImpId = mapResponseBidsByImpId(responseBody);
+
+  return {
+    ...adapterResponse,
+    bids: (adapterResponse?.bids ?? []).map(bid => {
+      const rawBid = rawBidsByImpId.get(bid.requestId);
+      return {
+        ...bid,
+        ttl: bid.ttl ?? rawBid?.ttl ?? rawBid?.exp ?? DEFAULT_TTL,
+        netRevenue: bid.netRevenue ?? rawBid?.netRevenue ?? DEFAULT_NET_REVENUE,
+      };
+    }),
+  };
+};
+
 const interpretResponse = (serverResponse, bidRequest) => {
   if (!serverResponse?.body) {
     return [];
   }
-  return converter.fromORTB({ request: bidRequest.data, response: serverResponse.body });
+  return enrichBidResponse(
+    converter.fromORTB({ request: bidRequest.data, response: serverResponse.body }),
+    serverResponse.body
+  );
 };
 
 const getUserSyncs: GetUserSyncFn = (syncOptions, _serverResponses, gdprConsent, uspConsent, gppConsent) => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->

This PR fixes Pubstack bid response enrichment for OpenRTB responses that provide `ttl` and `netRevenue` fields outside of the default ORTB converter mapping.

The Pubstack adapter already relies on the ORTB converter for standard bid response fields, but some exchanges return:
- `seatbid[].bid[].ttl` instead of `seatbid[].bid[].exp`
- `seatbid[].bid[].netRevenue` instead of values supplied through converter context

To support these responses, the adapter enriches converted bids after `fromORTB()` by matching raw bids by `impid` and backfilling:
- `ttl` from `rawBid.ttl`, then `rawBid.exp`, then the adapter default
- `netRevenue` from `rawBid.netRevenue`, then the adapter default

This prevents valid Pubstack bids from being rejected by Prebid validation when these required fields are missing after ORTB conversion.

The change is scoped to the Pubstack bid adapter and includes test coverage for response mapping.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
